### PR TITLE
[TM-18] Feat(정인재): 공통컴포넌트 드롭다운 UI 완성

### DIFF
--- a/src/components/@shared/DropDown.tsx
+++ b/src/components/@shared/DropDown.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState, ReactNode, ReactElement } from "react";
+
+interface Props {
+  visibility: boolean;
+  children: ReactNode;
+}
+
+export default function Dropdown({ visibility, children }: Props) {
+  const [visibilityAnimation, setVisibilityAnimation] =
+    useState<boolean>(false);
+  const [repeat, setRepeat] = useState<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (visibility) {
+      clearTimeout(repeat!);
+      setRepeat(null);
+      setVisibilityAnimation(true);
+    } else {
+      setRepeat(
+        setTimeout(() => {
+          setVisibilityAnimation(false);
+        }, 400),
+      );
+    }
+  }, [visibility]);
+
+  return (
+    <div className="h-[92px] w-[101px] rounded-2xl border border-light-gray-300 bg-light-white">
+      {visibilityAnimation && (
+        <ul>
+          {React.Children.map(children, (child, index) => {
+            if (React.isValidElement(child)) {
+              return React.cloneElement(child as ReactElement, {
+                className: `w-[93px] h-[40px] rounded-[10px] bg-light-purple-10 p-2 rounded-md py-2.5`, // li 배경색과 스타일 적용
+              });
+            }
+            return child;
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/@shared/DropDown.tsx
+++ b/src/components/@shared/DropDown.tsx
@@ -1,10 +1,5 @@
-import React, {
-  useEffect,
-  useState,
-  useRef,
-  ReactNode,
-  ReactElement,
-} from "react";
+import useToggle from "@/hooks/useToggle";
+import React, { useEffect, useRef, ReactNode, ReactElement } from "react";
 
 interface Props {
   children: ReactNode;
@@ -13,19 +8,21 @@ interface Props {
 }
 
 export default function Dropdown({ buttonChildren, children, width }: Props) {
-  const [isVisible, setIsVisible] = useState(false);
+  const [isVisible, setIsVisible] = useToggle(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
+      if (!isVisible) {
+        return;
+      }
       if (
         dropdownRef.current &&
         !dropdownRef.current.contains(e.target as Node)
       ) {
-        setIsVisible(false);
+        setIsVisible();
       }
     }
-
     if (isVisible) {
       window.addEventListener("click", handleClickOutside);
     } else {
@@ -41,9 +38,8 @@ export default function Dropdown({ buttonChildren, children, width }: Props) {
     <div className="relative" ref={dropdownRef}>
       <button
         onClick={() => {
-          setIsVisible(!isVisible);
+          setIsVisible();
         }}
-        className="flex-end"
       >
         {React.cloneElement(buttonChildren as ReactElement)}
       </button>
@@ -63,13 +59,4 @@ export default function Dropdown({ buttonChildren, children, width }: Props) {
       )}
     </div>
   );
-}
-
-{
-  /* <div className="flex flex-col items-center justify-center">
-  <Dropdown width="w-[126px] mx-auto" buttonChildren={<div>커스텀</div>}>
-    <li>마이페이지</li>
-    <li>로그아웃</li>
-  </Dropdown>
-</div>; */
 }

--- a/src/components/@shared/DropDown.tsx
+++ b/src/components/@shared/DropDown.tsx
@@ -1,37 +1,60 @@
-import React, { useEffect, useState, ReactNode, ReactElement } from "react";
+import React, {
+  useEffect,
+  useState,
+  useRef,
+  ReactNode,
+  ReactElement,
+} from "react";
 
 interface Props {
-  visibility: boolean;
   children: ReactNode;
+  width: string;
+  buttonChildren: ReactNode;
 }
 
-export default function Dropdown({ visibility, children }: Props) {
-  const [visibilityAnimation, setVisibilityAnimation] =
-    useState<boolean>(false);
-  const [repeat, setRepeat] = useState<NodeJS.Timeout | null>(null);
+export default function Dropdown({ buttonChildren, children, width }: Props) {
+  const [isVisible, setIsVisible] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (visibility) {
-      clearTimeout(repeat!);
-      setRepeat(null);
-      setVisibilityAnimation(true);
-    } else {
-      setRepeat(
-        setTimeout(() => {
-          setVisibilityAnimation(false);
-        }, 400),
-      );
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node)
+      ) {
+        setIsVisible(false);
+      }
     }
-  }, [visibility]);
+
+    if (isVisible) {
+      window.addEventListener("click", handleClickOutside);
+    } else {
+      window.removeEventListener("click", handleClickOutside);
+    }
+
+    return () => {
+      window.removeEventListener("click", handleClickOutside);
+    };
+  }, [isVisible]);
 
   return (
-    <div className="h-[92px] w-[101px] rounded-2xl border border-light-gray-300 bg-light-white">
-      {visibilityAnimation && (
-        <ul>
-          {React.Children.map(children, (child, index) => {
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => {
+          setIsVisible(!isVisible);
+        }}
+        className="flex-end"
+      >
+        {React.cloneElement(buttonChildren as ReactElement)}
+      </button>
+      {isVisible && (
+        <ul
+          className={`absolute right-0 z-50 flex h-[104px] flex-col items-center justify-center gap-1 ${width} rounded-2xl border border-light-gray-300 bg-light-white`}
+        >
+          {React.Children.map(children, (child) => {
             if (React.isValidElement(child)) {
               return React.cloneElement(child as ReactElement, {
-                className: `w-[93px] h-[40px] rounded-[10px] bg-light-purple-10 p-2 rounded-md py-2.5`, // li 배경색과 스타일 적용
+                className: `w-11/12 h-[46px] rounded-xl bg-light-white text-light-black text-lg-16px-medium flex items-center justify-center text-center rounded-md hover:bg-light-purple-10 hover:text-light-purple-100`, // li 배경색과 스타일 적용
               });
             }
             return child;
@@ -40,4 +63,13 @@ export default function Dropdown({ visibility, children }: Props) {
       )}
     </div>
   );
+}
+
+{
+  /* <div className="flex flex-col items-center justify-center">
+  <Dropdown width="w-[126px] mx-auto" buttonChildren={<div>커스텀</div>}>
+    <li>마이페이지</li>
+    <li>로그아웃</li>
+  </Dropdown>
+</div>; */
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,4 @@
+import Dropdown from "@/components/@shared/DropDown";
 import Link from "next/link";
 
 export default function HomePage() {
@@ -18,6 +19,11 @@ export default function HomePage() {
       <br />
       <Link href="/oauth/signup/kakao">카카오 간편 회원가입 페이지</Link>
       <br />
+
+      <Dropdown visibility={true}>
+        <li>마이페이지</li>
+        <li>d</li>
+      </Dropdown>
     </div>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,11 +19,6 @@ export default function HomePage() {
       <br />
       <Link href="/oauth/signup/kakao">카카오 간편 회원가입 페이지</Link>
       <br />
-
-      <Dropdown visibility={true}>
-        <li>마이페이지</li>
-        <li>d</li>
-      </Dropdown>
     </div>
   );
 }


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입을 선택해 주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타: 직접작성

## 작업 내용

- 드롭다운 UI 및 기능 구현완료하였습니다!
```
<div className="flex flex-col items-center justify-center">
        <Dropdown width="w-[126px] mx-auto" buttonChildren={<div>커스텀</div>}>
             <li>마이페이지</li>
             <li>로그아웃</li>
        </Dropdown>
</div>
```
- 해당 임시 각주를 넣어놓았는데 외부에서 사용하실 때 위의 코드를 확인하시면서 사용하시면 될 것 같습니다!
- 드롭다운을 열 버튼을 buttonChildren 프롭으로 넘겨서 이용하시면 됩니다 ( 아래 사진의 커스텀 텍스트 )
-  li태그에 요소들을 넣어주시면 되고 width 사이즈는 각각 달라서 이것 또한 프롭스로 넘기도록 구현하였습니다!

## 이미지 첨부 (선택)
![image](https://github.com/user-attachments/assets/821f4b9c-93e3-4dc1-bd73-b8a19163641f)
마우스 호버시 UI

