### PR TITLE
[TM-45] Feat(정인재): API 호출 기능 구현

### DIFF
--- a/src/libs/axios/wine/wineList.ts
+++ b/src/libs/axios/wine/wineList.ts
@@ -1,0 +1,37 @@
+import { Wines } from "@/types/wines";
+import axiosInstance from "../axiosInstance";
+
+export async function getWines() {
+  const response = await axiosInstance.get(`wines?limit=50`);
+
+  const body = response.data.list ?? [];
+
+  console.log(body);
+
+  return body;
+}
+
+export async function getWineRecommends() {
+  const response = await axiosInstance.get(`wines/recommended?limit=50`);
+
+  const body = response.data.list ?? [];
+
+  return body;
+}
+
+export async function postWines({ name, region, image, price, type }: Wines) {
+  const response = await axiosInstance.post(
+    "wines",
+    { name, region, image, price, type },
+    {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization:
+          "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTQ0LCJ0ZWFtSWQiOiI4LTYiLCJzY29wZSI6ImFjY2VzcyIsImlhdCI6MTcyNTA5NTI4NiwiZXhwIjoxNzI1MDk3MDg2LCJpc3MiOiJzcC1lcGlncmFtIn0.ziAzwFjjxbd0H1F-n1_cPEoQtPVmqDIwIOdhhTYqvT8",
+      },
+    },
+  );
+  const body = response.data;
+
+  return body;
+}

--- a/src/pages/wines/index.tsx
+++ b/src/pages/wines/index.tsx
@@ -1,3 +1,45 @@
+import {
+  getWineRecommends,
+  getWines,
+  postWines,
+} from "@/libs/axios/wine/wineList";
+import { Wine, Wines } from "@/types/wines";
+import { useEffect, useState } from "react";
+
 export default function WineListPage() {
-  return <div>와인 목록 페이지</div>;
+  const [wineListTest, setWineListTest] = useState([]);
+
+  const [wineValue, setWineValue] = useState<Wines>({
+    name: "",
+    region: "",
+    image:
+      "https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Sprint_Mission/user/3/1721991786504/31563.png",
+    price: 0,
+    type: Wine.Red,
+  });
+
+  async function fetchWines() {
+    const wineList = await getWines(); //와인 목록 조회
+    const wineRecommendList = await getWineRecommends(); //추천 와인 목록 조회
+    setWineListTest(wineList);
+  }
+
+  useEffect(() => {
+    fetchWines();
+  }, []);
+
+  const handleSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    const result = await postWines(wineValue);
+    if (!result) {
+      console.log("wine 등록 중 오류 발생");
+    }
+  };
+
+  return (
+    <div>
+      와인 목록 페이지
+      <button onClick={handleSubmit}>wine 등록</button>
+    </div>
+  );
 }

--- a/src/types/wines.ts
+++ b/src/types/wines.ts
@@ -1,0 +1,13 @@
+export enum Wine {
+  Red = "RED",
+  White = "WHITE",
+  Sparkling = "SPARKLING",
+}
+
+export interface Wines {
+  name: string;
+  region: string;
+  image: string | null;
+  price: number;
+  type: Wine;
+}


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입을 선택해 주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타: 직접작성

## 작업 내용
- 와인 목록 조회 (GET) , 와인 추천 목록 조회 (GET) , 와인 등록 (POST) API를 구현하고 호출해보았습니다.
- 샘플 데이터가 없어서 와인등록(POST) API로 임시 와인 데이터 두개를 넣어뒀습니다.
- 와인 관련 API에 사용될 와인 Type들을 만들었습니다
- POST API를 사용할 때 토큰이 필요하여 임시로 request.http 파일을 만들어서 토큰을 발급받아서 사용하고 있습니다.

## 이미지 첨부 (선택)
POST 후 와인 목록 조회(GET)을 콘솔로 찍어보았을 때 결과
![image](https://github.com/user-attachments/assets/cb98b5de-4879-4867-8148-7a6d43f61b64)

