### PR TITLE
[TM-19] CI/CD(이형준): 배포 자동화 GitHub Action 작성

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Sync forked repo for deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+      - name: creates output
+        run: sh ./build.sh
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.AUTO_REPO_TOKEN }}
+        with:
+          source-directory: "output"
+          destination-github-username: leehj322
+          destination-repository-name: wine
+          user-email: ${{ secrets.OFFICIAL_ACCOUNT_EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: main
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd ../
+mkdir output
+cp -R ./wine/* ./output
+cp -R ./output ./wine/


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입을 선택해 주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타: 직접작성

## 작업 내용

- main 브랜치에 push 하는 경우 해당 브랜치를 제 개인 레포로 sync 시킨 후에 vercel 에 배포하는 과정을 자동화 했습니다.
- 해당 동작을 수행하는 github action (deploy.yml) 과 해당 action 을 실행하는데 필요한 build.sh를 추가하였습니다.
- 참고링크 : https://velog.io/@rmaomina/organization-vercel-hobby-deploy
