### PR TITLE
[TM-88] Feat(이형준): 드롭다운 반응형 및 디자인 선택지 추가

### DIFF
--- a/src/components/@shared/DropDown.tsx
+++ b/src/components/@shared/DropDown.tsx
@@ -5,9 +5,21 @@ interface Props {
   children: ReactNode;
   width: string;
   buttonChildren: ReactNode;
+  childType?: "menu" | "wine";
 }
 
-export default function Dropdown({ buttonChildren, children, width }: Props) {
+/**
+ * Dropdown 공통 컴포넌트
+ * @params buttonChildren: dropdown visible 값을 토글하는 버튼 디자인 컴포넌트
+ * @params width: dropdown box의 width 값
+ * @params childType?: 우측정렬 (wine), 가운데 정렬 (menu) / 기본값 : 가운데정렬
+ */
+export default function Dropdown({
+  buttonChildren,
+  children,
+  width,
+  childType = "menu",
+}: Props) {
   const [isVisible, setIsVisible] = useToggle(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -35,22 +47,25 @@ export default function Dropdown({ buttonChildren, children, width }: Props) {
   }, [isVisible]);
 
   return (
-    <div className="relative" ref={dropdownRef}>
+    <div className="relative inline-block" ref={dropdownRef}>
       <button
         onClick={() => {
           setIsVisible();
         }}
       >
-        {React.cloneElement(buttonChildren as ReactElement)}
+        {buttonChildren}
       </button>
       {isVisible && (
         <ul
-          className={`absolute right-0 z-50 flex h-[104px] flex-col items-center justify-center gap-1 ${width} rounded-2xl border border-light-gray-300 bg-light-white`}
+          className={`absolute right-0 top-[calc(100%+6px)] z-40 m-0 flex flex-col items-center justify-center rounded-2xl border border-light-gray-300 bg-light-white px-1 py-1 ${width}`}
         >
           {React.Children.map(children, (child) => {
             if (React.isValidElement(child)) {
               return React.cloneElement(child as ReactElement, {
-                className: `w-11/12 h-[46px] rounded-xl bg-light-white text-light-black text-lg-16px-medium flex items-center justify-center text-center rounded-md hover:bg-light-purple-10 hover:text-light-purple-100`, // li 배경색과 스타일 적용
+                className:
+                  childType === "menu"
+                    ? `flex w-full items-center justify-center rounded-xl py-2 text-md-14px-medium text-light-black hover:bg-light-purple-10 hover:text-light-purple-100 md:py-[10px] md:text-lg-16px-medium`
+                    : `flex w-full items-center rounded-xl px-4 py-2 text-md-14px-medium text-light-black hover:bg-light-purple-10 hover:text-light-purple-100 md:py-[10px] md:text-lg-16px-medium`,
               });
             }
             return child;


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입을 선택해 주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타: 직접작성

## 작업 내용

- 선택지를 2개 3개로 한정하지 않고 여러개 계속 추가하더라도 디자인이 맞춰서 호환되도록 변경
- childType prop을 추가해서 wine의 type을 선택하는 dropdown (왼쪽 정렬) 스타일과 일반 menu dropdown (가운데 정렬) 스타일을 지정 가능
- 반응형 으로 폰트 및 사이즈가 변하도록 추가 (width 값은 외부에서 전달해야함)

## 이미지 첨부 (선택)

예시 (예시 코드의 input select 컴포넌트는 사용법 올바르지 않음!)
![image](https://github.com/user-attachments/assets/958b6c38-0d83-4f8c-84d8-17fb63d22917)
![image](https://github.com/user-attachments/assets/5bef48f6-d2c7-4a21-805d-1e142177f0b0)

