### PR TITLE
[TM-90]  Feat(이형준): 버튼 커스텀 스타일 및 반응형 추가

### DIFF
--- a/src/components/@shared/Button.tsx
+++ b/src/components/@shared/Button.tsx
@@ -6,14 +6,14 @@ interface CommonButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  buttonStyle: "gray" | "light" | "purple"; // 버튼 스타일 지정해주세요.
+  buttonStyle?: "gray" | "light" | "purple";
+  customStyle?: string;
+  shape?: "pill" | "normal";
   children: ReactNode;
 }
 
 /**
  * 기본 스타일을 적용하는 CommonButton 컴포넌트
- * @param {CommonButtonProps} props - CommonButton의 프롭스
- * @returns {JSX.Element} 버튼 요소
  */
 function CommonButton({
   additionalStyle,
@@ -22,7 +22,7 @@ function CommonButton({
 }: CommonButtonProps) {
   return (
     <button
-      className={`${additionalStyle} flex h-full w-full items-center justify-center rounded-2xl text-lg-16px-bold`}
+      className={`flex h-full w-full items-center justify-center md:text-lg-16px-bold ${additionalStyle}`}
       {...props}
     >
       {children}
@@ -32,41 +32,41 @@ function CommonButton({
 
 /**
  * 다양한 스타일을 가진 버튼을 생성하는 Button 컴포넌트
- * @param {ButtonProps} props - Button의 프롭스
- * @returns {JSX.Element} 스타일에 맞는 버튼 요소
+ * @param buttonStyle gray(회색), light(연보라색), purple(보라색), undefined(social login 용)
+ * @param shape 버튼의 모양 pill(border 9999px), normal(border 12px)
+ * @param customStyle tailwind className customStyle 용
  */
 export default function Button({
   buttonStyle,
+  customStyle = "",
+  shape = "normal",
   children,
   ...props
 }: ButtonProps) {
+  const roundedStyle = shape === "pill" ? "rounded-full" : "rounded-2xl";
+
+  let additionalStyle = "";
   switch (buttonStyle) {
     case "gray":
-      return (
-        <CommonButton
-          additionalStyle="border border-solid border-light-gray-300 bg-light-white text-light-gray-500"
-          {...props}
-        >
-          {children}
-        </CommonButton>
-      );
+      additionalStyle = `border border-solid border-light-gray-300 bg-light-white text-md-14px-medium text-light-gray-500`;
+      break;
     case "light":
-      return (
-        <CommonButton
-          additionalStyle="bg-violet-100 text-lg-16px-bold text-light-purple-100"
-          {...props}
-        >
-          {children}
-        </CommonButton>
-      );
+      additionalStyle = `bg-violet-100 text-md-14px-bold text-light-purple-100`;
+      break;
+    case "purple":
+      additionalStyle = `bg-light-purple-100 text-md-14px-bold text-light-white`;
+      break;
     default:
-      return (
-        <CommonButton
-          additionalStyle="bg-light-purple-100 text-light-white"
-          {...props}
-        >
-          {children}
-        </CommonButton>
-      );
+      additionalStyle = `border border-solid border-light-gray-300 bg-light-white text-md-14px-medium text-light-gray-800`;
+      break;
   }
+
+  return (
+    <CommonButton
+      additionalStyle={`${additionalStyle} ${roundedStyle} ${customStyle}`}
+      {...props}
+    >
+      {children}
+    </CommonButton>
+  );
 }


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입을 선택해 주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타: 직접작성

## 작업 내용

- 버튼에 반응형을 추가하고 스타일을 변경할 수 있는 prop을 추가하였습니다
- customStyle을 통해 tailwind css 의 className을 넘겨주면 적용 가능합니다
- shape라는 속성을 추가해서 버튼이 알약모양인지 일반 모서리만 둥근 모양인지 선택가능합니다
- buttonStyle 속성으로 아무 값도 넘겨주지 않는 경우의 버튼 스타일을 추가했습니다.

## 이미지 첨부 (선택)

사용법
![image](https://github.com/user-attachments/assets/7ea0660c-6377-4cdb-922a-131d0e7c9fdc)
![image](https://github.com/user-attachments/assets/76a0bc78-d01b-4525-abde-717ad71c88e2)
