### PR TITLE
[TM-111] Design(정인재): PriceRangeInput 디자인 및 로직 수정

### DIFF
--- a/src/components/@shared/PriceRangeInput.tsx
+++ b/src/components/@shared/PriceRangeInput.tsx
@@ -32,28 +32,37 @@ export default function PriceRangeInput({
 }: PriceRangeInputProps) {
   const [minValue, setMinValue] = useState(minPrice);
   const [maxValue, setMaxValue] = useState(maxPrice);
+  const [tempMinValue, setTempMinValue] = useState(minPrice);
+  const [tempMaxValue, setTempMaxValue] = useState(maxPrice);
+
+  useEffect(() => {
+    if (onPriceChange) {
+      onPriceChange(minValue, maxValue);
+    }
+  }, [minValue, maxValue]);
 
   useEffect(() => {
     const progress = document.querySelector<HTMLElement>(".slider .progress");
 
     if (progress) {
-      progress.style.left = `${(minValue / maxPrice) * 100}%`;
-      progress.style.right = `${100 - (maxValue / maxPrice) * 100}%`;
+      progress.style.left = `${(tempMinValue / maxPrice) * 100}%`;
+      progress.style.right = `${100 - (tempMaxValue / maxPrice) * 100}%`;
     }
-
-    if (onPriceChange) {
-      onPriceChange(minValue, maxValue);
-    }
-  }, [minValue, maxValue, maxPrice, onPriceChange]);
+  }, [tempMinValue, tempMaxValue]);
 
   const handleMinChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = Math.min(Number(e.target.value), maxValue - priceGap);
-    setMinValue(value);
+    setTempMinValue(value);
   };
 
   const handleMaxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = Math.max(Number(e.target.value), minValue + priceGap);
-    setMaxValue(value);
+    setTempMaxValue(value);
+  };
+
+  const handleMouseUp = () => {
+    setMinValue(tempMinValue);
+    setMaxValue(tempMaxValue);
   };
 
   return (
@@ -63,10 +72,10 @@ export default function PriceRangeInput({
           <div className="slider relative h-[6px] rounded-[50px] bg-light-gray-100">
             <div className="progress absolute left-1/4 right-1/4 h-[6px] rounded-[50px] bg-light-purple-100" />
             <span className="thumb-label min-label text-lg-16px-medium text-light-purple-100">
-              ₩ {minValue.toLocaleString()}
+              ₩ {tempMinValue.toLocaleString()}
             </span>
             <span className="thumb-label max-label text-lg-16px-medium text-light-purple-100">
-              ₩ {maxValue.toLocaleString()}
+              ₩ {tempMaxValue.toLocaleString()}
             </span>
           </div>
           <div className="range-input relative">
@@ -75,18 +84,20 @@ export default function PriceRangeInput({
               className="range-min"
               min={DEFAULT_MIN_PRICE}
               max={DEFAULT_MAX_PRICE}
-              value={minValue}
+              value={tempMinValue}
               step={1000}
               onChange={handleMinChange}
+              onMouseUp={handleMouseUp}
             />
             <input
               type="range"
               className="range-max"
               min={DEFAULT_MIN_PRICE}
               max={DEFAULT_MAX_PRICE}
-              value={maxValue}
+              value={tempMaxValue}
               step={1000}
               onChange={handleMaxChange}
+              onMouseUp={handleMouseUp}
             />
           </div>
         </div>
@@ -132,12 +143,13 @@ export default function PriceRangeInput({
 
           .min-label {
             transform: translateX(-20%);
-            left: ${(minValue / DEFAULT_MAX_PRICE) * 100}%;
+            top: 12px;
+            left: ${(tempMinValue / DEFAULT_MAX_PRICE) * 100}%;
           }
 
           .max-label {
             transform: translateX(-70%);
-            left: ${(maxValue / DEFAULT_MAX_PRICE) * 100}%;
+            left: ${(tempMaxValue / DEFAULT_MAX_PRICE) * 100}%;
           }
         `}
       </style>


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입을 선택해 주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타: 직접작성

## 작업 내용

- 기존 PriceRange의 min, max값이 가까워질때 텍스트가 겹치는 문제가 있어서 minTextUi를 아래로 내려서 겹치지 않도록 수정했습니다.
- PriceRange가 이동할 때마다 값이 업데이터 되는 로직이 getApi요청을 무수히 많이 보내는 문제점을 일으켜서 Range가 마우스에서 out 될때만 get요청을 보내도록 로직을 수정하였습니다.

## 이미지 첨부 (선택)
![image](https://github.com/user-attachments/assets/8f79c84a-0846-44b0-86c3-526a885f79b5)
min max값이 가까울 때 텍스트가 겹치지않는 모습
![image](https://github.com/user-attachments/assets/2d228c59-b983-45f1-9b68-f81e6dfca2d3)

