### PR TITLE
[TM-119] Refector(정인재) 과도한 데이터 요청 및 폴더 구조 리팩토링 

### DIFF
--- a/src/components/@shared/DropDown.tsx
+++ b/src/components/@shared/DropDown.tsx
@@ -50,8 +50,8 @@ export default function Dropdown({
     <div className="relative inline-block" ref={dropdownRef}>
       <button
         className="w-full"
+        type="button"
         onClick={(e: React.MouseEvent) => {
-          e.preventDefault();
           setIsVisible();
         }}
       >

--- a/src/components/@shared/PriceRangeInput.tsx
+++ b/src/components/@shared/PriceRangeInput.tsx
@@ -1,3 +1,4 @@
+import useDebounce from "@/hooks/useDebounce";
 import React, { useEffect, useState } from "react";
 
 interface PriceRangeInputProps {
@@ -35,11 +36,13 @@ export default function PriceRangeInput({
   const [minValue, setMinValue] = useState(minPrice);
   const [maxValue, setMaxValue] = useState(maxPrice);
 
+  const debouncedValue = useDebounce({ minValue, maxValue }, 300);
+
   useEffect(() => {
     if (onPriceChange) {
-      onPriceChange(minValue, maxValue);
+      onPriceChange(debouncedValue.minValue, debouncedValue.maxValue);
     }
-  }, [minValue, maxValue]);
+  }, [debouncedValue.minValue, debouncedValue.maxValue]);
 
   useEffect(() => {
     const progress = document.querySelector<HTMLElement>(".slider .progress");

--- a/src/components/wines/Filter/WineFilter.tsx
+++ b/src/components/wines/Filter/WineFilter.tsx
@@ -1,83 +1,15 @@
-import { ReactNode, useCallback } from "react";
+import { useCallback } from "react";
 import useToggle from "@/hooks/useToggle";
 import { WineEnum, WineFilterProps } from "@/types/wines";
-import PriceRangeInput from "../@shared/PriceRangeInput";
-import Button from "../@shared/Button";
-import useDebounce from "@/hooks/useDebounce";
+import PriceRangeInput from "../../@shared/PriceRangeInput";
+import Button from "../../@shared/Button";
+import WineTypeRadio from "./WineTypeRadio";
+import WineRatingRadio from "./WineRatingRadio";
 
 interface Props {
   wineFilterValue: WineFilterProps;
   onFilterChange: (newFilterValue: WineFilterProps) => void;
   onClose: () => void;
-}
-
-interface WineTypeProps {
-  children: ReactNode;
-  value: WineEnum;
-  selectedValue: WineEnum | null;
-  onChange: (value: WineEnum) => void;
-}
-
-interface WineRatingProps {
-  children: ReactNode;
-  value: number;
-  selectedValue: number | null;
-  onChange: (value: number) => void;
-}
-
-function WineTypeRadio({
-  children,
-  value,
-  selectedValue,
-  onChange,
-}: WineTypeProps) {
-  return (
-    <button
-      className={`flex h-[42px] cursor-pointer items-center justify-center rounded-full border border-solid border-gray-300 border-light-gray-300 px-4 ${
-        selectedValue === value
-          ? "bg-light-purple-100 text-light-white"
-          : "bg-light-white text-light-black"
-      } `}
-      onClick={() => onChange(value)}
-    >
-      <input
-        type="radio"
-        name="wineType"
-        value={value}
-        style={{ display: "none" }}
-        checked={selectedValue === value}
-        onChange={() => {}}
-      />
-      <span> {children}</span>
-    </button>
-  );
-}
-
-function WineRatingRadio({
-  children,
-  value,
-  selectedValue,
-  onChange,
-}: WineRatingProps) {
-  return (
-    <div className="] flex items-center gap-4">
-      <input
-        type="radio"
-        id="red"
-        name="wineRating"
-        style={{
-          width: "18px",
-          height: "18px",
-          border: "5px solid #F2F4F8",
-          borderRadius: "30%",
-          backgroundColor: selectedValue === value ? "#6A42DB" : "#F2F4F8", // 보라색
-          boxShadow: "0 0 0 1px#CFDBEA", // 추가 테두리 효과
-        }}
-        onClick={() => onChange(value)}
-      />
-      <span>{children}</span>
-    </div>
-  );
 }
 
 export default function WineFilter({

--- a/src/components/wines/Filter/WineRatingRadio.tsx
+++ b/src/components/wines/Filter/WineRatingRadio.tsx
@@ -1,0 +1,35 @@
+import { ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  value: number;
+  selectedValue: number | null;
+  onChange: (value: number) => void;
+}
+
+export default function WineRatingRadio({
+  children,
+  value,
+  selectedValue,
+  onChange,
+}: Props) {
+  return (
+    <div className="] flex items-center gap-4">
+      <input
+        type="radio"
+        id="red"
+        name="wineRating"
+        style={{
+          width: "18px",
+          height: "18px",
+          border: "5px solid #F2F4F8",
+          borderRadius: "30%",
+          backgroundColor: selectedValue === value ? "#6A42DB" : "#F2F4F8", // 보라색
+          boxShadow: "0 0 0 1px#CFDBEA", // 추가 테두리 효과
+        }}
+        onClick={() => onChange(value)}
+      />
+      <span>{children}</span>
+    </div>
+  );
+}

--- a/src/components/wines/Filter/WineTypeRadio.tsx
+++ b/src/components/wines/Filter/WineTypeRadio.tsx
@@ -1,0 +1,37 @@
+import { ReactNode } from "react";
+import { WineEnum } from "@/types/wines";
+
+interface Props {
+  children: ReactNode;
+  value: WineEnum;
+  selectedValue: WineEnum | null;
+  onChange: (value: WineEnum) => void;
+}
+
+export default function WineTypeRadio({
+  children,
+  value,
+  selectedValue,
+  onChange,
+}: Props) {
+  return (
+    <button
+      className={`flex h-[42px] cursor-pointer items-center justify-center rounded-full border border-solid border-gray-300 border-light-gray-300 px-4 ${
+        selectedValue === value
+          ? "bg-light-purple-100 text-light-white"
+          : "bg-light-white text-light-black"
+      } `}
+      onClick={() => onChange(value)}
+    >
+      <input
+        type="radio"
+        name="wineType"
+        value={value}
+        style={{ display: "none" }}
+        checked={selectedValue === value}
+        onChange={() => {}}
+      />
+      <span> {children}</span>
+    </button>
+  );
+}

--- a/src/components/wines/WineFilter.tsx
+++ b/src/components/wines/WineFilter.tsx
@@ -3,6 +3,7 @@ import useToggle from "@/hooks/useToggle";
 import { WineEnum, WineFilterProps } from "@/types/wines";
 import PriceRangeInput from "../@shared/PriceRangeInput";
 import Button from "../@shared/Button";
+import useDebounce from "@/hooks/useDebounce";
 
 interface Props {
   wineFilterValue: WineFilterProps;
@@ -112,14 +113,13 @@ export default function WineFilter({
       wineRating: value,
     });
   };
+
   const handlePriceChange = useCallback(
     (min: number, max: number) => {
       if (
         wineFilterValue.winePrice.min !== min ||
         wineFilterValue.winePrice.max !== max
       ) {
-        // 값이 변경되었을 때만 onFilterChange 호출
-
         onFilterChange({
           ...wineFilterValue,
           winePrice: { min, max },

--- a/src/components/wines/WineRecommendItemList.tsx
+++ b/src/components/wines/WineRecommendItemList.tsx
@@ -4,6 +4,7 @@ import getWineRecommends from "@/libs/axios/wine/getWineRecommends";
 import { useRef, useState, useEffect } from "react";
 import MEDIA_QUERY_BREAK_POINT from "@/constants/mediaQueryBreakPoint";
 import Rating from "../@shared/Rating";
+import Link from "next/link";
 
 interface WineProps {
   wine: Wine;
@@ -127,7 +128,7 @@ export default function WineRecommendItemList() {
           {hasWineButtons.isLeftBtnVisible && (
             <button
               type="button"
-              className="absolute left-4 top-1/2 flex h-[48px] w-[48px] -translate-y-1/2 items-center justify-center rounded-full border border-solid border-light-gray-300 bg-light-white"
+              className="absolute left-4 top-1/2 z-10 flex h-[48px] w-[48px] -translate-y-1/2 items-center justify-center rounded-full border border-solid border-light-gray-300 bg-light-white"
               onClick={() => handleClick("left")}
             >
               <Image
@@ -146,7 +147,9 @@ export default function WineRecommendItemList() {
             style={{ scrollBehavior: "smooth" }}
           >
             {wineRecommends.map((wine) => (
-              <WineRecommendCard key={wine.id} wine={wine} />
+              <Link key={wine.id} href={`/wines/${wine.id.toString()}`}>
+                <WineRecommendCard key={wine.id} wine={wine} />
+              </Link>
             ))}
           </div>
           {hasWineButtons.isRightBtnVisible && (

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+const useDebounce = <T>(value: T, delay: number) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    }; //value 변경 시점에 clearTimeout을 해줘야함.
+  }, [value]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;

--- a/src/libs/axios/wine/getWines.ts
+++ b/src/libs/axios/wine/getWines.ts
@@ -9,12 +9,14 @@ export interface Response {
 export default async function getWines(
   limit: number,
   wineFilter: WineFilterProps,
+  debouncedWineName: string,
   wineCursor: number | null,
 ): Promise<Response> {
   try {
-    const { wineType, winePrice, wineName, wineRating } = wineFilter;
+    const { wineType, winePrice, wineRating } = wineFilter;
+    console.log(debouncedWineName);
     const response = await axiosInstance.get<Response>(
-      `/wines?limit=${limit}&type=${wineType}&minPrice=${winePrice.min}&maxPrice=${winePrice.max}&name=${wineName}&rating=${wineRating}&cursor=${wineCursor}`,
+      `/wines?limit=${limit}&type=${wineType}&minPrice=${winePrice.min}&maxPrice=${winePrice.max}&name=${debouncedWineName}&rating=${wineRating}&cursor=${wineCursor}`,
     );
 
     const list = response.data.list ?? [];

--- a/src/libs/axios/wine/getWines.ts
+++ b/src/libs/axios/wine/getWines.ts
@@ -14,7 +14,6 @@ export default async function getWines(
 ): Promise<Response> {
   try {
     const { wineType, winePrice, wineRating } = wineFilter;
-    console.log(debouncedWineName);
     const response = await axiosInstance.get<Response>(
       `/wines?limit=${limit}&type=${wineType}&minPrice=${winePrice.min}&maxPrice=${winePrice.max}&name=${debouncedWineName}&rating=${wineRating}&cursor=${wineCursor}`,
     );

--- a/src/pages/wines/index.tsx
+++ b/src/pages/wines/index.tsx
@@ -1,4 +1,4 @@
-import WineFilter from "@/components/wines/WineFilter";
+import WineFilter from "@/components/wines/Filter/WineFilter";
 import WineItemList from "@/components/wines/WineItemList";
 import WineRecommendItemList from "@/components/wines/WineRecommendItemList";
 import getWines from "@/libs/axios/wine/getWines";

--- a/src/pages/wines/index.tsx
+++ b/src/pages/wines/index.tsx
@@ -174,7 +174,7 @@ export default function WineListPage() {
 
         {isMobileView && (
           <>
-            <div className="hidden h-[45px] w-[284px] max-xl:block max-xl:w-[220px] max-md:fixed max-md:bottom-5 max-md:w-[calc(100%-80px)]">
+            <div className="z-10 hidden h-[45px] w-[284px] max-xl:block max-xl:w-[220px] max-md:fixed max-md:bottom-5 max-md:w-[calc(100%-80px)]">
               <Button
                 onClick={() => toggleIsAddWineModalOpen()}
                 buttonStyle="purple"

--- a/src/types/wines.ts
+++ b/src/types/wines.ts
@@ -89,5 +89,4 @@ export interface WineFilterProps {
   wineType: WineEnum;
   winePrice: WinePrice;
   wineRating: number;
-  wineName: string;
 }


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입을 선택해 주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [x] 코드 리팩토링
- [x] 버그 수정
- [ ] 기타: 직접작성

## 작업 내용

- debounce훅을 만들어 검색, priceValue스크롤을 움직일 때 과도하게 get요청을 하던 부분을 지연시켜 요청횟수를 대폭 줄였습니다.
- 버튼들이 이미지에 씹히는 버그들을 해결했습니다.
- 와인 추천 리스트들의 카드들도 이제 클릭하면 상세페이지로 이동하도록 수정했습니다.
- 필터 폴더를 만들고 필터 컴포넌트에 있는 radio, type들의 컴포넌트를 모두 분리하여 폴더안에 배치하여서 좀 더 컴포넌트들을 보기 쉽도록 조정했습니다.
- 불필요한 주석이나 로직들을 수정했습니다.

## 이미지 첨부 (선택)

- 없음
