### PR TITLE
[TM-14] Fix(손재헌): auth page 1차 수정 dev 병합

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  images: {
-    domains: ["sprint-fe-project.s3.ap-northeast-2.amazonaws.com", "i.namu.wiki"],
-  },
-};

--- a/src/components/auth/KakaoOauthButton.tsx
+++ b/src/components/auth/KakaoOauthButton.tsx
@@ -24,8 +24,8 @@ export default function KakaoOauthButton() {
   const handleAuthCode = () => {
     const token = localStorage.getItem("authCode");
     if (!token) return;
+    localStorage.removeItem("authCode");
     handleSubmit(token);
-    localStorage.removeItem("authToken");
   };
 
   useEffect(() => {


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입을 선택해 주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 코드 리팩토링
- [x] 버그 수정
- [ ] 기타: 직접작성

## 작업 내용

- next.config.js를 삭제해서 이제 소셜 로그인시 프로필 이미지가 정상적으로 불러와집니다.
- 카카오 로그인시 발급받은 code가 로컬스토리지에서 삭제되지 않고 잔류하던 문제를 수정했습니다.

## 이미지 첨부 (선택)

- 없음
