### PR TITLE
[TM-14] Fix(손재헌): auth page 1차 수정 dev 병합

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  images: {
-    domains: ["sprint-fe-project.s3.ap-northeast-2.amazonaws.com", "i.namu.wiki"],
-  },
-};

--- a/src/components/auth/KakaoOauthButton.tsx
+++ b/src/components/auth/KakaoOauthButton.tsx
@@ -24,8 +24,8 @@ export default function KakaoOauthButton() {
   const handleAuthCode = () => {
     const token = localStorage.getItem("authCode");
     if (!token) return;
+    localStorage.removeItem("authCode");
     handleSubmit(token);
-    localStorage.removeItem("authToken");
   };
 
   useEffect(() => {

--- a/src/utils/getAuthFormError.ts
+++ b/src/utils/getAuthFormError.ts
@@ -25,7 +25,7 @@ export function getPasswordErrorMessage(password: string) {
   if (!password) return "비밀번호는 필수 입력입니다.";
   if (!isCorrectPassword(password))
     return "비밀번호는 숫자, 영문, 특수문자로만 가능합니다.";
-  if (password.length < 8) return "비밀번호는 최소 8자 이상입니다..";
+  if (password.length < 8) return "비밀번호는 최소 8자 이상입니다.";
   return "";
 }
 


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입을 선택해 주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 코드 리팩토링
- [x] 버그 수정
- [ ] 기타: 직접작성

## 작업 내용

- 카카오 로그인시 발급받은 code가 삭제되지 않고 로컬 스토리지에 잔류하던 것을 삭제하도록 수정했습니다.
- next.config.js 파일을 삭제해서 이제 소셜 로그인시 프로필 이미지가 정상적으로 불러와집니다.
- 패스워드 입력시 에러 메세지가 이제 아련하지 않고 단호합니다.

## 이미지 첨부 (선택)

- 없음
